### PR TITLE
chore: add a prepare script 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "fix:prettier": "prettier -w .",
     "clean:coverage": "rimraf coverage",
     "pretest": "run-s -s clean",
-    "prepack": "run-s -s build"
+    "prepack": "run-s -s build",
+    "prepare": "npm run build"
   },
   "keywords": [],
   "author": "Steve Konves",


### PR DESCRIPTION
This PR adds a `prepare` script to the `justworkshr/basketry-sorbet` package.json.

This solution was taken from this [Stack OverFlow Forum](https://stackoverflow.com/questions/40528053/npm-install-and-build-of-forked-github-repo). The issue was that the package wasn't being built when the package was installed via the `justworkshr` GH repo. 

The idea is that the `prepare` script will run when the package is installed via the CLI.